### PR TITLE
Bug: Fix vector dimension when data is used for training on a subset of the grid

### DIFF
--- a/sciann/models/model.py
+++ b/sciann/models/model.py
@@ -711,7 +711,7 @@ class SciModel(object):
                     adjusted_yt = yt[1]
                     if ids.size == yt[1].shape[0] and ids.size < num_sample:
                         adjusted_yt = np.zeros((num_sample,)+yt[1].shape[1:])
-                        adjusted_yt[ids, :] = yt[1]
+                        adjusted_yt[ids] = yt[1]
                     elif yt[1].shape[0] != num_sample:
                         raise ValueError(
                             'Error in size of the target {}.'.format(i)


### PR DESCRIPTION
When training using data on a subset of the grid, vector has wrong dimension: should be one dimensional, was two dimensional.