### PR TITLE
fix save_weights argument in model.train to use 'freq' value instead of always using 10 as callback period

### DIFF
--- a/sciann/models/model.py
+++ b/sciann/models/model.py
@@ -464,7 +464,7 @@ class SciModel(object):
                     model_file_path = save_weights_path + "-best.hdf5"
                     model_check_point = k.callbacks.ModelCheckpoint(
                         model_file_path, monitor='loss', save_weights_only=True, mode='auto',
-                        period=save_weights['freq'] if 'freq' in save_weights.keys() else 10,
+                        period=save_weights.get('freq', 10),
                         save_best_only=True
                     )
                 else:
@@ -472,7 +472,7 @@ class SciModel(object):
                     model_file_path = save_weights_path + "-{epoch:05d}-{loss:.3e}.hdf5"
                     model_check_point = k.callbacks.ModelCheckpoint(
                         model_file_path, monitor='loss', save_weights_only=True, mode='auto',
-                        period=save_weights['freq'] if 'freq' in save_weights.keys() else 10,
+                        period=save_weights.get('freq', 10),
                         save_best_only=False
                     )
             except:

--- a/sciann/models/model.py
+++ b/sciann/models/model.py
@@ -464,7 +464,7 @@ class SciModel(object):
                     model_file_path = save_weights_path + "-best.hdf5"
                     model_check_point = k.callbacks.ModelCheckpoint(
                         model_file_path, monitor='loss', save_weights_only=True, mode='auto',
-                        period=10 if 'freq' in save_weights.keys() else save_weights['freq'],
+                        period=save_weights['freq'] if 'freq' in save_weights.keys() else 10,
                         save_best_only=True
                     )
                 else:
@@ -472,7 +472,7 @@ class SciModel(object):
                     model_file_path = save_weights_path + "-{epoch:05d}-{loss:.3e}.hdf5"
                     model_check_point = k.callbacks.ModelCheckpoint(
                         model_file_path, monitor='loss', save_weights_only=True, mode='auto',
-                        period=10 if 'freq' in save_weights.keys() else save_weights['freq'],
+                        period=save_weights['freq'] if 'freq' in save_weights.keys() else 10,
                         save_best_only=False
                     )
             except:


### PR DESCRIPTION
Issue: ["https://github.com/sciann/sciann/issues/54"](https://github.com/sciann/sciann/issues/54)

```python
history = model.train(inputs_train, len(losses)*['zero'], batch_size=100, learning_rate=0.001,
               save_weights={"path":'./weights','freq':200})
```
When executing the above code with the **save_weights** parameter, **weights are saved every 10 epoch** irrespective of what we pass in the **'freq'** key of the **save_weights** argument.

I figured out the code which I think is logically incorrect, in the **sciann.model** class's **train** function and updated the same to get expected behavior (10 as default value of 'freq' if the key is not specified).